### PR TITLE
Use @compulim/* for internal packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "handler-chain-root",
+  "name": "@compulim/handler-chain-root",
   "version": "0.1.1-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "handler-chain-root",
+      "name": "@compulim/handler-chain-root",
       "version": "0.1.1-0",
       "license": "MIT",
       "workspaces": [
@@ -62,6 +62,14 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@compulim/handler-chain-integration-test": {
+      "resolved": "packages/integration-test",
+      "link": true
+    },
+    "node_modules/@compulim/handler-chain-pages": {
+      "resolved": "packages/pages",
+      "link": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
@@ -712,9 +720,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4259,14 +4267,6 @@
     },
     "node_modules/handler-chain": {
       "resolved": "packages/handler-chain",
-      "link": true
-    },
-    "node_modules/handler-chain-integration-test": {
-      "resolved": "packages/integration-test",
-      "link": true
-    },
-    "node_modules/handler-chain-pages": {
-      "resolved": "packages/pages",
       "link": true
     },
     "node_modules/has-bigints": {
@@ -8041,7 +8041,7 @@
       }
     },
     "packages/integration-test": {
-      "name": "handler-chain-integration-test",
+      "name": "@compulim/handler-chain-integration-test",
       "version": "0.0.0-0",
       "license": "MIT",
       "dependencies": {
@@ -8057,7 +8057,7 @@
       }
     },
     "packages/pages": {
-      "name": "handler-chain-pages",
+      "name": "@compulim/handler-chain-pages",
       "version": "0.0.0-0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "handler-chain-root",
+  "name": "@compulim/handler-chain-root",
   "version": "0.1.1-0",
   "description": "",
   "private": true,

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "handler-chain-integration-test",
+  "name": "@compulim/handler-chain-integration-test",
   "version": "0.0.0-0",
   "description": "",
   "private": true,

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "handler-chain-pages",
+  "name": "@compulim/handler-chain-pages",
   "version": "0.0.0-0",
   "description": "",
   "private": true,


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

## Specific changes

> Please list each individual specific change in this pull request.

- Moved all private packages to `@compulim/*`
- Added `.npmrc` with `ignore-scripts=true`